### PR TITLE
Added support for missing targets to ConfusionMatrix

### DIFF
--- a/test/test_confusion.lua
+++ b/test/test_confusion.lua
@@ -27,3 +27,7 @@ cm:updateValids()
 
 print'ConfusionMatrix:__tostring__() test'
 print(cm)
+
+target = 0
+cm:add(prediction, target)
+assert(cm.mat:sum() == batch_size + 1, 'too many examples')


### PR DESCRIPTION
This PR adds support for missing targets (targets <= 0) to the ConfusionMatrix. Includes a unit test. Also fixed a typo in method `specificity`.
