### PR TITLE
Fixed sign in update rule & reconciled code with version 4 of the paper 

### DIFF
--- a/adam.lua
+++ b/adam.lua
@@ -47,7 +47,7 @@ function optim.adam(opfunc, x, config, state)
     -- Decay the first moment running average coefficient
     local bt1 = 1 - beta1 * lambda^(state.t - 1)
 
-    state.m:mul(bt1):add(bt1, dfdx)
+    state.m:mul(bt1):add(1-bt1, dfdx)
     state.v:mul(beta2):addcmul(1-beta2, dfdx, dfdx)
 
     state.denom:copy(state.v):sqrt():add(epsilon)

--- a/adam.lua
+++ b/adam.lua
@@ -24,10 +24,10 @@ function optim.adam(opfunc, x, config, state)
     -- (0) get/update state
     local config = config or {}
     local state = state or config
-    local lr = config.learningRate or 2e-4
+    local lr = config.learningRate or 0.001
 
-    local beta1 = config.beta1 or 0.1
-    local beta2 = config.beta2 or 0.001
+    local beta1 = config.beta1 or 0.9
+    local beta2 = config.beta2 or 0.999
     local epsilon = config.epsilon or 1e-8
     local lambda = config.lambda or 1-1e-8
 
@@ -45,18 +45,18 @@ function optim.adam(opfunc, x, config, state)
 
     state.t = state.t + 1
     -- Decay the first moment running average coefficient
-    local bt1 = 1 - (1 - beta1) * lambda^(state.t - 1)
+    local bt1 = 1 - beta1 * lambda^(state.t - 1)
 
-    state.m:mul(1 - bt1):add(bt1, dfdx)
-    state.v:mul(1 - beta2):addcmul(beta2, dfdx, dfdx)
+    state.m:mul(bt1):add(bt1, dfdx)
+    state.v:mul(beta2):addcmul(1-beta2, dfdx, dfdx)
 
     state.denom:copy(state.v):sqrt():add(epsilon)
 
-    local biasCorrection1 = 1 - (1 - beta1)^state.t
-    local biasCorrection2 = 1 - (1 - beta2)^state.t
+    local biasCorrection1 = 1 - beta1^state.t
+    local biasCorrection2 = 1 - beta2^state.t
     local stepSize = lr * math.sqrt(biasCorrection2)/biasCorrection1
     -- (2) update x
-    x:addcdiv(-stepSize, state.m, state.denom)
+    x:addcdiv(stepSize, state.m, state.denom)
 
     -- return x*, f(x) before optimization
     return x, {fx}

--- a/adam.lua
+++ b/adam.lua
@@ -45,7 +45,7 @@ function optim.adam(opfunc, x, config, state)
 
     state.t = state.t + 1
     -- Decay the first moment running average coefficient
-    local bt1 = 1 - beta1 * lambda^(state.t - 1)
+    local bt1 = beta1 * lambda^(state.t - 1)
 
     state.m:mul(bt1):add(1-bt1, dfdx)
     state.v:mul(beta2):addcmul(1-beta2, dfdx, dfdx)

--- a/test/test_adam.lua
+++ b/test/test_adam.lua
@@ -1,0 +1,19 @@
+require 'torch'
+require 'optim'
+require 'rosenbrock'
+require 'l2'
+x = torch.Tensor(2):fill(0)
+fx = {}
+config = {learningRate=0.002}
+for i = 1,10001 do
+x,f=optim.adam(rosenbrock,x,config)
+if (i-1)%1000 == 0 then
+table.insert(fx,f[1])
+end
+end
+print()
+print('Rosenbrock test')
+print()
+print('x=');print(x)
+print('fx=')
+for i=1,#fx do print((i-1)*1000+1,fx[i]); end


### PR DESCRIPTION
The sign in the update rule in version 4 (3rd March) of the paper does'nt seem to work? The code works when the update to the parameters is positive not negative? To be precise, on page 2, the fifth line up from the bottom should be,

`theta_t <- theta_t-1 + alpha_t . m_t / (sqrt(v_t) + epsilon )`

not

`theta_t <- theta_t-1 - alpha_t . m_t / (sqrt(v_t) + epsilon )`

Made some cosmetic changes to reconciled the code with version 4 of the paper