### PR TITLE
Add ADADELTA algorithm

### DIFF
--- a/adadelta.lua
+++ b/adadelta.lua
@@ -41,9 +41,20 @@ function optim.adadelta(opfunc, x, config, state)
 
     state.accSquaredGradsWithDecay:mul(decay):addcmul(1.0 - decay, dfdx, dfdx)
 
-    local prev_rms_delta =
-        state.accSquaredDeltaWithDecay:clone():add(eps):sqrt()
-    local rms_grad = state.accSquaredGradsWithDecay:clone():add(eps):sqrt()
+    local prev_rms_delta = torch.Tensor()
+        :typeAs(state.accSquaredDeltaWithDecay)
+        :resizeAs(state.accSquaredDeltaWithDecay)
+        :zero()
+        :add(state.accSquaredDeltaWithDecay)
+        :add(eps)
+        :sqrt()
+    local rms_grad = torch.Tensor()
+        :typeAs(state.accSquaredGradsWithDecay)
+        :resizeAs(state.accSquaredGradsWithDecay)
+        :zero()
+        :add(state.accSquaredGradsWithDecay)
+        :add(eps)
+        :sqrt()    
     local delta = prev_rms_delta:cdiv(rms_grad):cmul(dfdx):mul(-1.0)
 
     state.accSquaredDeltaWithDecay:mul(decay):addcmul(1.0 - decay, delta, delta)

--- a/adadelta.lua
+++ b/adadelta.lua
@@ -1,0 +1,54 @@
+--[[ A plain implementation of ADADELTA 
+    http://www.matthewzeiler.com/pubs/googleTR2012/googleTR2012.pdf
+
+    ARGS:
+
+    - `opfunc` : a function that takes a single input (X), the point
+    of a evaluation, and returns f(X) and df/dX
+    - `x`      : the initial point
+    - `config` : a table with configuration parameters for the optimizer
+    - `config.decayRate`           : decay rate
+    - `config.offset`              : offset
+    - `state`  : a table describing the state of the optimizer; after each
+    call the state is modified
+    - `state.accSquaredDeltaWithDecay`
+               : vector of accumulated squared deltas from previous steps
+    with corresponding decay rate
+    - `state.accSquaredGradsWithDecay`
+               : vector of accumulated squared gradients from previous steps
+    with corresponding decay rate
+    RETURN:
+    - `x`     : the new x vector
+    - `f(x)`  : the function, evaluated before the update
+]]
+function optim.adadelta(opfunc, x, config, state)
+    local config = config or {}
+    local state = state or config
+    local decay = config.decayRate or 0.9
+    local eps = config.offset or 1e-6
+
+    assert(decay >= 0 and decay <= 1, "Wrong value for decay rate: " .. decay)
+    assert(eps >= 0, "Wrong value for offset constant: " .. eps)
+
+    local fx, dfdx = opfunc(x)
+
+    if not state.accSquaredDeltaWithDecay then
+        state.accSquaredDeltaWithDecay =
+            torch.Tensor():typeAs(x):resizeAs(x):zero()
+        state.accSquaredGradsWithDecay =
+            torch.Tensor():typeAs(dfdx):resizeAs(dfdx):zero()
+    end
+
+    state.accSquaredGradsWithDecay:mul(decay):addcmul(1.0 - decay, dfdx, dfdx)
+
+    local prev_rms_delta =
+        state.accSquaredDeltaWithDecay:clone():add(eps):sqrt()
+    local rms_grad = state.accSquaredGradsWithDecay:clone():add(eps):sqrt()
+    local delta = prev_rms_delta:cdiv(rms_grad):cmul(dfdx):mul(-1.0)
+
+    state.accSquaredDeltaWithDecay:mul(decay):addcmul(1.0 - decay, delta, delta)
+
+    x:add(delta)
+
+    return x, {fx}
+end

--- a/init.lua
+++ b/init.lua
@@ -11,6 +11,7 @@ torch.include('optim', 'nag.lua')
 torch.include('optim', 'fista.lua')
 torch.include('optim', 'lbfgs.lua')
 torch.include('optim', 'adagrad.lua')
+torch.include('optim', 'adadelta.lua')
 torch.include('optim', 'rprop.lua')
 torch.include('optim', 'adam.lua')
 

--- a/test/test_adadelta.lua
+++ b/test/test_adadelta.lua
@@ -1,0 +1,23 @@
+require 'torch'
+require 'optim'
+
+require 'rosenbrock'
+require 'l2'
+
+x = torch.Tensor(2):fill(0)
+fx = {}
+
+config = {decayRate=0.9, offset=1e-10}
+for i = 1,10001 do
+	x,f=optim.adadelta(rosenbrock,x,config)
+	if (i-1)%1000 == 0 then
+		table.insert(fx,f[1])
+	end
+end
+
+print()
+print('Rosenbrock test')
+print()
+print('x=');print(x)
+print('fx=')
+for i=1,#fx do print((i-1)*1000+1,fx[i]); end


### PR DESCRIPTION
Just one more optimization algorithm. I wonder if that will be helpful for others.

Paper: http://www.matthewzeiler.com/pubs/googleTR2012/googleTR2012.pdf

Test plan:

    $ luarocks make optim-1.0.5-0.rockspec
    $ cd test
    $ luarocks make

    $ th test_adadelta.lua
    Rosenbrock test
    x=
     0.9932
     0.9861
    [torch.DoubleTensor of dimension 2]    

    fx=
    1	1
    1001	0.85674832729526
    2001	0.65380034382089
    3001	0.45083429533603
    4001	0.27774607313817
    5001	0.14830309667068
    6001	0.06446454527491
    7001	0.019846854100354
    8001	0.0029878163396553
    9001	0.00021361750977478
    10001	6.034663542954e-05    

    $ th test_adagrad.lua
    Rosenbrock test
    x=
     1.0000
     1.0000
    [torch.DoubleTensor of dimension 2]    

    fx=
    1	1
    1001	0.0096629336429242
    2001	0.0011605963642662
    3001	0.00017238390470642
    4001	0.00037591610790092
    5001	4.4145804955209e-06
    6001	7.1646069394023e-07
    7001	1.1654181321944e-07
    8001	1.8974400763049e-08
    9001	3.090397609615e-09
    10001	5.0341388774798e-10    
    

