### PR TITLE
fixing rmsprop bug

### DIFF
--- a/rmsprop.lua
+++ b/rmsprop.lua
@@ -38,7 +38,7 @@ function optim.rmsprop(opfunc, x, config, state)
     state.m:addcmul(1.0-alpha,dfdx,dfdx)
 
     -- (4) perform update
-    state.tmp:copy(state.m):sqrt()
+    state.tmp:sqrt(state.m)
     x:addcdiv(-lr, dfdx, state.tmp:add(epsilon))
 
     -- return x*, f(x) before optimization

--- a/rmsprop.lua
+++ b/rmsprop.lua
@@ -9,9 +9,6 @@ ARGS:
 - 'config.learningRate'      : learning rate
 - 'config.alpha'             : smoothing constant
 - 'config.epsilon'           : value with which to inistialise m
-- 'config.epsilon2'          : stablisation to prevent mean square going to zero
-- 'config.max_gain'          : stabilisation to prevent lr multiplier exploding
-- 'config.min_gain'          : stabilisation to prevent lr multiplier exploding
 - 'state = {m, dfdx_sq}'     : a table describing the state of the optimizer; after each
                               call the state is modified
 
@@ -25,27 +22,24 @@ function optim.rmsprop(opfunc, x, config, state)
     -- (0) get/update state
     local config = config or {}
     local state = state or config
-    local lr = config.learningRate or 1e-4
-    local alpha = config.alpha or 0.998
+    local lr = config.learningRate or 1e-2
+    local alpha = config.alpha or 0.95
     local epsilon = config.epsilon or 1e-8
-    local epsilon2 = config.epsilon2 or 1e-8
-    local max_gain = config.max_gain or 1000
-    local min_gain = config.min_gain or 1e-8
 
     -- (1) evaluate f(x) and df/dx
     local fx, dfdx = opfunc(x)
 
     -- (2) initialize mean square values and square gradient storage
-    state.m = state.m or torch.Tensor():typeAs(dfdx):resizeAs(dfdx):fill(epsilon)
+    state.m = state.m or torch.Tensor():typeAs(dfdx):resizeAs(dfdx):zero()
     state.tmp = state.tmp or x.new(dfdx:size()):zero()
 
-    -- (3) calculate new mean squared values
+    -- (3) calculate new (leaky) mean squared values
     state.m:mul(alpha)
-    state.m:addcmul(1.0-alpha,dfdx,dfdx):add(epsilon2)
+    state.m:addcmul(1.0-alpha,dfdx,dfdx)
 
     -- (4) perform update
-    state.tmp:copy(state.m):pow(-0.5):clamp(min_gain, max_gain)
-    x:add(-lr, state.tmp)
+    state.tmp:copy(state.m):sqrt()
+    x:addcdiv(-lr, dfdx, state.tmp:add(epsilon))
 
     -- return x*, f(x) before optimization
     return x, {fx}, state.tmp

--- a/test/test_rmsprop.lua
+++ b/test/test_rmsprop.lua
@@ -1,0 +1,23 @@
+require 'torch'
+require 'optim'
+
+require 'rosenbrock'
+require 'l2'
+
+x = torch.Tensor(2):fill(0)
+fx = {}
+
+config = {learningRate=5e-4}
+for i = 1,10001 do
+	x,f=optim.rmsprop(rosenbrock,x,config)
+	if (i-1)%1000 == 0 then
+		table.insert(fx,f[1])
+	end
+end
+
+print()
+print('Rosenbrock test')
+print()
+print('x=');print(x)
+print('fx=')
+for i=1,#fx do print((i-1)*1000+1,fx[i]); end


### PR DESCRIPTION
The current [RMSProp implementation](https://github.com/torch/optim/blob/master/rmsprop.lua) has a critical bug in the following line:

```lua
x:add(-lr, state.tmp)
```

I think the code was trying to **multiply** the learning rate to the `state.tmp` variable and then add it to `x` to perform the parameter update, but right now it's just adding them and adding the result to `x`. I noticed this because my RNN wasn't training with RMSProp at all, when this worked very nicely in my near equivalent Python codebase. 

This pull request fixes the RMSProp implementation and cleans up the code/hyperparams. RMSProp normally has three parameters:

- The learning rate
- The decay rate (`alpha`)
- The smoothing term (`epsilon`)

I fixed the code to contain exactly these three parameters. I also adjusted the code to look similar to what `adagrad.lua` looks like, except the running sum of squares is leaky in RMSProp. I also set the default hyperparameters to values that normally work for me in practice, at least when training RNNs.
