### PR TITLE
New features in Logger

### DIFF
--- a/Logger.lua
+++ b/Logger.lua
@@ -53,6 +53,7 @@ function Logger:__init(filename, timestamp)
    self.names = {}
    self.idx = {}
    self.figure = nil
+   self.showPlot = true
 end
 
 function Logger:setNames(names)
@@ -148,10 +149,12 @@ function Logger:plot(...)
       end
    end
    if plotit then
-      self.figure = gnuplot.figure(self.figure)
-      gnuplot.plot(plots)
-      gnuplot.grid('on')
-      gnuplot.title('<Logger::' .. self.name .. '>')
+      if self.showPlot then
+         self.figure = gnuplot.figure(self.figure)
+         gnuplot.plot(plots)
+         gnuplot.grid('on')
+         gnuplot.title('<Logger::' .. self.name .. '>')
+      end
       if self.epsfile then
          os.execute('rm -f "' .. self.epsfile .. '"')
          local epsfig = gnuplot.epsfigure(self.epsfile)

--- a/Logger.lua
+++ b/Logger.lua
@@ -54,6 +54,8 @@ function Logger:__init(filename, timestamp)
    self.idx = {}
    self.figure = nil
    self.showPlot = true
+   self.plotRawCmd = nil
+   self.defaultStyle = '+'
 end
 
 function Logger:setNames(names)
@@ -63,7 +65,7 @@ function Logger:setNames(names)
    for k,key in pairs(names) do
       self.file:write(key .. '\t')
       self.symbols[k] = {}
-      self.styles[k] = {'+'}
+      self.styles[k] = {self.defaultStyle}
       self.idx[key] = k
    end
    self.file:write('\n')
@@ -78,7 +80,7 @@ function Logger:add(symbols)
       for k,val in pairs(symbols) do
          self.file:write(k .. '\t')
          self.symbols[k] = {}
-         self.styles[k] = {'+'}
+         self.styles[k] = {self.defaultStyle}
          self.names[k] = k
       end
       self.idx = self.names
@@ -152,6 +154,7 @@ function Logger:plot(...)
       if self.showPlot then
          self.figure = gnuplot.figure(self.figure)
          gnuplot.plot(plots)
+         if self.plotRawCmd then gnuplot.raw(self.plotRawCmd) end
          gnuplot.grid('on')
          gnuplot.title('<Logger::' .. self.name .. '>')
       end
@@ -159,6 +162,7 @@ function Logger:plot(...)
          os.execute('rm -f "' .. self.epsfile .. '"')
          local epsfig = gnuplot.epsfigure(self.epsfile)
          gnuplot.plot(plots)
+         if self.plotRawCmd then gnuplot.raw(self.plotRawCmd) end
          gnuplot.grid('on')
          gnuplot.title('<Logger::' .. self.name .. '>')
          gnuplot.plotflush()


### PR DESCRIPTION
I propose adding three simple features:
- option to disable showing of plots while still saving plots in a file
- option to set the default symbol
- option to be able to pass a raw command to gnuplot

The new options are 'hidden', meaning they are not exposed in __init() and don't change the old behavior.