### PR TITLE
Change ConfusionMatrix accumulator from Float to Long.

### DIFF
--- a/ConfusionMatrix.lua
+++ b/ConfusionMatrix.lua
@@ -17,7 +17,7 @@ function ConfusionMatrix:__init(nclasses, classes)
       classes = nclasses
       nclasses = #classes
    end
-   self.mat = torch.FloatTensor(nclasses,nclasses):zero()
+   self.mat = torch.LongTensor(nclasses,nclasses):zero()
    self.valids = torch.FloatTensor(nclasses):zero()
    self.unionvalids = torch.FloatTensor(nclasses):zero()
    self.nclasses = nclasses


### PR DESCRIPTION
This might be the worlds smallest PR :-)

self.mat is only ever used as an integer accumulator, and so we're wasting a lot of bits...  The max number of samples per matrix element is 2^24 = 16777216, which is actually pretty small (I hit the limit in my particular application).  In retrospect, self.mat should have always been a LongTensor.

I don't think there are any unintended consequences.  But if someone could do a quick scan of the code to double check, that would  be awesome.

Cheers,
Jonathan