### PR TITLE
return optim in init.lua.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -26,3 +26,5 @@ torch.include('optim', 'checkgrad.lua')
 -- tools
 torch.include('optim', 'ConfusionMatrix.lua')
 torch.include('optim', 'Logger.lua')
+
+return optim


### PR DESCRIPTION
It seems like optim is the only library that I use where:

``optim = require('optim')``

doesn't work (at the moment the return value is just ``true``).  To fix this I've added a ``return optim`` statement to the end of ``init.lua``.