### PR TITLE
checkgrad.lua: tensor type bug when using gpu

### DIFF
--- a/checkgrad.lua
+++ b/checkgrad.lua
@@ -25,7 +25,7 @@ function optim.checkgrad(opfunc, x, eps)
     
     -- compute numeric approximations to gradient:
     local eps = eps or 1e-7
-    local dC_est = torch.DoubleTensor(dC:size())
+    local dC_est = torch.Tensor():typeAs(dC):resizeAs(dC)
     for i = 1,dC:size(1) do
       x[i] = x[i] + eps
       local C1 = opfunc(x)


### PR DESCRIPTION
When the _,dC = opfunc(x) is a gpu tensor, there will be an error:
/bin/luajit: bad argument #2 to '?' (number expected, got userdata)
stack traceback:
        [C]: at 0x7fc541dc8040
        [C]: in function '__sub'

This is fixed by ``local dC_est = torch.Tensor():typeAs(dC):resizeAs(dC)'' which ensures dC_est and dC have the same tensor type.