### PR TITLE
Fix possible type mismatch in ConfusionMatrix

### DIFF
--- a/ConfusionMatrix.lua
+++ b/ConfusionMatrix.lua
@@ -109,6 +109,8 @@ function ConfusionMatrix:batchAdd(predictions, targets)
 
    self._mat_flat = self._mat_flat or self.mat:view(-1) -- for backward compatibility
 
+   preds = preds:typeAs(targs)
+
    assert(self.mat:isContiguous() and self.mat:stride(2) == 1)
    local indices = ((targs - 1) * self.mat:stride(1) + preds):typeAs(self.mat)
    local ones = torch.ones(1):typeAs(self.mat):expand(indices:size(1))


### PR DESCRIPTION
Reported in comments to https://github.com/torch/optim/commit/207bb273b7eb0362a77d67a4e2493bfaa0e425db.

`preds` and `targs` can be either a `LongTensor` or a `FloatTensor`, and if their types don't match it crashes when trying to add them.