### PR TITLE
Init rmsprop mean square state 'm' with 1 instead 0

### DIFF
--- a/rmsprop.lua
+++ b/rmsprop.lua
@@ -40,7 +40,7 @@ function optim.rmsprop(opfunc, x, config, state)
 
     -- (3) initialize mean square values and square gradient storage
     if not state.m then
-      state.m = torch.Tensor():typeAs(x):resizeAs(dfdx):zero()
+      state.m = torch.Tensor():typeAs(x):resizeAs(dfdx):fill(1)
       state.tmp = torch.Tensor():typeAs(x):resizeAs(dfdx)
     end
 


### PR DESCRIPTION
With alpha near 1 (e.g. the default value 0.99) the gradient was
likely scaled up due to a division by a number <1 during the first
few iterations.
With the original impl the learning rate had to be set to a much
smaller value when using rmsprop compared to plain-vanilla sgd in
order not to diverge.