### PR TITLE
One-line Logger initialisation

### DIFF
--- a/Logger.lua
+++ b/Logger.lua
@@ -76,6 +76,7 @@ function Logger:setNames(names)
    end
    self.file:write('\n')
    self.file:flush()
+   return self
 end
 
 function Logger:add(symbols)
@@ -120,6 +121,7 @@ function Logger:style(symbols)
          xlua.error('style should be a string or a table of strings','Logger')
       end
    end
+   return self
 end
 
 function Logger:setlogscale(value)


### PR DESCRIPTION
A `Logger` can be created and setup in one line

```lua
log = optim.logger('foo'):setNames{'a', 'b'}:style{'-', '-'}
```