### PR TITLE
Copy C1 value, in case it is a Tensor reference

### DIFF
--- a/checkgrad.lua
+++ b/checkgrad.lua
@@ -20,8 +20,14 @@ RETURN:
 function optim.checkgrad(opfunc, x, eps)
     
     -- compute true gradient:
-    local _,dC = opfunc(x)
+    local Corg,dC = opfunc(x)
     dC:resize(x:size())
+    
+    local Ctmp -- temporary value
+    local isTensor = torch.isTensor(Corg)
+    if isTensor then
+          Ctmp = Corg.new(Corg:size())
+    end
     
     -- compute numeric approximations to gradient:
     local eps = eps or 1e-7
@@ -30,6 +36,10 @@ function optim.checkgrad(opfunc, x, eps)
       local tmp = x[i]
       x[i] = x[i] + eps
       local C1 = opfunc(x)
+      if isTensor then
+          Ctmp:copy(C1)
+          C1 = Ctmp
+      end
       x[i] = x[i] - 2 * eps
       local C2 = opfunc(x)
       x[i] = tmp


### PR DESCRIPTION
When opfunc() simply returns the output state variable of a nn model (ie. when opfunc() simply returns my_net:forward()'s output), the second opfunc() call within the for loop updates not only C2, but also C1. In this case, dC_est is wrongly 0. Avoid this behaviour by blindly copying C1 contents when it is a Tensor/CudaTensor. The overhead should be bearable as C1 is a scalar.