### PR TITLE
Reverted to zero mean squared values init

### DIFF
--- a/rmsprop.lua
+++ b/rmsprop.lua
@@ -40,7 +40,7 @@ function optim.rmsprop(opfunc, x, config, state)
 
    -- (3) initialize mean square values and square gradient storage
    if not state.m then
-      state.m = torch.Tensor():typeAs(x):resizeAs(dfdx):fill(1)
+      state.m = torch.Tensor():typeAs(x):resizeAs(dfdx):zero()
       state.tmp = torch.Tensor():typeAs(x):resizeAs(dfdx)
    end
 


### PR DESCRIPTION
Reverted to zero mean squared values initialisation `state.m`.

Since the gradients get divided by this moving average it might be sensible to be initialised with ones, since it avoids making big steps in the beginning.

However, this update resulted a substantial decrease in the performance of many of my projects, and I'm sure it's breaking more.