### PR TITLE
Prevent displaying of plots and documentation for it

### DIFF
--- a/Logger.lua
+++ b/Logger.lua
@@ -124,8 +124,12 @@ function Logger:style(symbols)
    return self
 end
 
-function Logger:setlogscale(value)
-   self.logscale = value
+function Logger:setlogscale(state)
+   self.logscale = state
+end
+
+function Logger:display(state)
+   self.showPlot = state
 end
 
 function Logger:plot(...)

--- a/doc/logger.md
+++ b/doc/logger.md
@@ -71,3 +71,9 @@ logger:plot()
 ![Logging plot](logger_plot.png)
 
 If we'd like an interactive visualisation, we can put the `logger:plot()` instruction within the `for` loop, and the chart will be updated at every iteration.
+
+In case we'd like to prevent `gnuplot` to display the plots, we can set the option `logger:display(false)`.
+In this way, plots will be saved but not displayed.
+To restore the normal behaviour, use `logger:display(true)`.
+
+We can set a logarithmic *y* axis with `logger:setlogscale(true)` and reset it with `logger:setlogscale(false)`.


### PR DESCRIPTION
The `Logger:display(state)` function gives user the flexibility to save the generated plots without displaying them.
Things added or changed as a result of the commits:
+ Added `display` function
+ `setlogscale` function parameter makes more sense now
+ Added documentation for these two functions