### PR TITLE
Fixed the link to the Adam research paper

### DIFF
--- a/adam.lua
+++ b/adam.lua
@@ -1,4 +1,4 @@
---[[ An implementation of Adam http://arxiv.org/pdf/1412.6980.pdf
+--[[ An implementation of Adam https://arxiv.org/abs/1412.6980
 
 ARGS:
 


### PR DESCRIPTION
Fixed the link to the, "Adam: A Method for Stochastic Optimization" research paper. 

This link no longer works: http://arxiv.org/pdf/1412.6980.pdf

I and many others involved with machine learning, find it's better to link to the research paper's arXiv page itself, and not directly to the PDF file. This is because it's not easy to get to the research paper's arXiv page, directly from the PDF, but it is easy to get to the PDF from the arXiv page. 

Using HTTPS instead of HTTP is also a better choice for security, privacy, and in some cases it may even be faster.  